### PR TITLE
[AZUL-82796] Arch/feat/aikido ignore

### DIFF
--- a/.aikido
+++ b/.aikido
@@ -1,0 +1,3 @@
+exclude:
+  paths:
+    - .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
  * Added an exclusion rule to ignore the `.yarn/releases/yarn-4.12.0.cjs` file.